### PR TITLE
bug example

### DIFF
--- a/packages/client-instagram/src/services/post.ts
+++ b/packages/client-instagram/src/services/post.ts
@@ -60,8 +60,36 @@ export class InstagramPostService {
       const randomMinutes = Math.floor(Math.random() * (maxMinutes - minMinutes + 1)) + minMinutes;
       const delay = randomMinutes * 60 * 1000;
 
-      if (Date.now() > lastPostTimestamp + delay) {
+      const shouldPost = Date.now() > lastPostTimestamp + delay;
+
+
+      if (shouldPost) {
         await this.generateNewPost();
+        await this.runtime.messageManager.createMemory({
+            id: stringToUuid(`instagram-post-${new Date(Date.now()).toISOString()}`),
+            userId: this.runtime.agentId,
+            agentId: this.runtime.agentId,
+            content: {
+                text: '',
+                postPublished: `Post published at ${new Date(Date.now()).toISOString()}`,
+            },
+            roomId: stringToUuid("instagram_generate_room-" + this.state.profile?.username),
+            embedding: getEmbeddingZeroVector(),
+            createdAt: Date.now(),
+          });
+      } else {
+        await this.runtime.messageManager.createMemory({
+            id: stringToUuid(`instagram-post-${new Date(Date.now()).toISOString()}`),
+            userId: this.runtime.agentId,
+            agentId: this.runtime.agentId,
+            content: {
+                text: '',
+                postRejected: `Post rejected at ${new Date(Date.now()).toISOString()}`,
+            },
+            roomId: stringToUuid("instagram_generate_room-" + this.state.profile?.username),
+            embedding: getEmbeddingZeroVector(),
+            createdAt: Date.now(),
+          });
       }
 
       if (!this.stopProcessing) {


### PR DESCRIPTION
## Bug Scenario

Let's analyze a case where a post is incorrectly skipped:

Initial settings:
- POST_INTERVAL_MIN = 90 minutes
- POST_INTERVAL_MAX = 180 minutes

Timeline:
1. 10:00 AM - First post is published
   - lastPostTimestamp = 10:00 AM
   - Generates delay = 150 minutes
   - Schedules next execution for 12:30 PM (after 150 minutes)

2. 12:30 PM - generatePostLoop executes
   - Generates NEW delay = 170 minutes
   - Checks: Date.now() (12:30 PM) > lastPostTimestamp (10:00 AM) + newDelay (170 minutes)?
   - 12:30 PM > 12:50 PM? → NO
   - shouldPost = false
   - Schedules next check for 15:20 PM (after 170 minutes)

The bug occurs because:
1. The decision to publish the current post is based on a NEWLY generated delay
2. If the new delay is longer than the previous one, the post won't be published even though the scheduled time has passed
3. This leads to extended gaps between posts that can exceed POST_INTERVAL_MAX

Root cause:
The current implementation incorrectly ties the execution of the current post to the random delay generation for the next post. These should be separate concerns - the current post should be published based on the previously scheduled delay, while the new delay should only determine the timing of the next post.

Code in this PR saves some additional records to DB to track posts publications in Instagram Client, client was running with theses intervals:
```
POST_INTERVAL_MIN=15
POST_INTERVAL_MAX=20
```
In result we can see that one post was skipped: 
![Zrzut ekranu 2025-01-23 140338](https://github.com/user-attachments/assets/f369eb8c-05f1-4cae-810a-99d1b5864320)

Similar behaviour may happen in clients where this condition occurs:
```
   if (Date.now() > lastPostTimestamp + delay) {
```
That is:
 - Instagram client
 - twitter client
 - farcaster client

